### PR TITLE
Fixed puredata examples to account for get_output

### DIFF
--- a/examples/puredata/pdbloop/main.py
+++ b/examples/puredata/pdbloop/main.py
@@ -12,7 +12,7 @@ from kivy.uix.label import Label
 from kivy.config import Config
 Config.set('graphics', 'maxfps', '30')
 
-from audiostream.core import AudioStream, AudioSample
+from audiostream import get_output
 from audiostream.sources.puredata import PatchSource
 
 CHANNELS = 2
@@ -27,12 +27,12 @@ class AudioApp(App):
                           allow_stretch=True,)
         label = Label(text="kivy+pd://bloopy.pd",
                       font_size=30)
-                          
+
         self.widget = StackLayout()
         self.widget.add_widget(logo_pd)
         self.widget.add_widget(label)
         self.widget.add_widget(logo_kivy)
-        self.stream = AudioStream(channels=CHANNELS, buffersize=BUFSIZE, rate=SAMPLERATE)
+        self.stream = get_output(channels=CHANNELS, buffersize=BUFSIZE, rate=SAMPLERATE)
         self.source = PatchSource(self.stream, 'bloopy.pd')
         self.source.start()
 

--- a/examples/puredata/pdpad/main.py
+++ b/examples/puredata/pdpad/main.py
@@ -12,7 +12,7 @@ from kivy.uix.label import Label
 from kivy.config import Config
 Config.set('graphics', 'maxfps', '30')
 
-from audiostream.core import AudioStream, AudioSample
+from audiostream import get_output
 from audiostream.sources.puredata import PatchSource
 
 from pylibpd import libpd_float, libpd_bang
@@ -40,14 +40,14 @@ class AudioApp(App):
                           allow_stretch=True,)
         label = Label(text="kivy+pd://funpad.pd",
                       font_size=30)
-                          
+
         self.widget = TouchableStack(self)
         self.widget.add_widget(logo_pd)
         self.widget.add_widget(label)
         self.widget.add_widget(logo_kivy)
-        self.stream = AudioStream(channels=CHANNELS, 
-                                  buffersize=BUFSIZE, 
-                                  rate=SAMPLERATE)
+        self.stream = get_output(channels=CHANNELS, 
+                                 buffersize=BUFSIZE, 
+                                 rate=SAMPLERATE)
         self.source = PatchSource(self.stream, 'funpad.pd')
         self.source.start()
 


### PR DESCRIPTION
Changed the puredata examples from audiostream.core.AudioStream to audiostream.get_output
