### PR TITLE
modified to use sdl2 for an android install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,9 +33,6 @@ else:
 use_sdl2 = environ.get('USE_SDL2')
 if use_sdl2:
     include_dirs = ['/usr/include/SDL2']
-    sdl_include_dir = environ.get('SDL2_INCLUDE_DIR')
-    if sdl_include_dir:
-        include_dirs.append(sdl_include_dir)
     libraries = ['SDL2', 'SDL2_mixer']
 else 
     libraries = ['SDL', 'SDL_mixer']

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ if use_sdl2:
     if sdl_include_dir:
         include_dirs.append(sdl_include_dir)
     libraries = ['SDL2', 'SDL2_mixer']
-else 
+else:
     libraries = ['SDL', 'SDL_mixer']
     include_dirs = ['/usr/include/SDL']
 library_dirs = []

--- a/setup.py
+++ b/setup.py
@@ -30,19 +30,19 @@ else:
         raise
 
 # configure the env
-libraries = ['SDL2', 'SDL2_mixer']
+use_sdl2 = os.environ.get('USE_SDL2')
+libraries = ['SDL2', 'SDL2_mixer'] if use_sdl2 else ['SDL', 'SDL_mixer']
 library_dirs = []
-include_dirs = ['/usr/include/SDL2', '/home/kivy/.buildozer/android/platform/android-ndk-r9c/sources/android/support/include']
+include_dirs = ['/usr/include/SDL2', '/home/kivy/.buildozer/android/platform/android-ndk-r9c/sources/android/support/include'] if use_sdl2 else ['/usr/include/SDL2']
 extra_objects = []
 extra_compile_args =['-ggdb', '-O2']
 extra_link_args = []
 extensions = []
 
 if not have_cython:
-    libraries = ['SDL2', 'SDL2_mixer']
+    libraries = ['SDL2', 'SDL2_mixer'] if use_sdl2 else ['sdl', 'sdl_mixer']
 else:
-    include_dirs.append('.')
-    include_dirs.append('/usr/include/SDL2')
+    include_dirs.insert(0, '.')
 
 # generate an Extension object from its dotted name
 def makeExtension(extName, files=None):
@@ -67,7 +67,7 @@ if platform == 'android':
 elif platform == 'ios':
     include_dirs = [
             join(kivy_ios_root, 'build', 'include'),
-            join(kivy_ios_root, 'build', 'include', 'SDL2')]
+            join(kivy_ios_root, 'build', 'include', 'SDL')]
     extra_link_args = [
         '-L', join(kivy_ios_root, 'build', 'lib'),
         '-undefined', 'dynamic_lookup']
@@ -75,7 +75,7 @@ elif platform == 'ios':
         [join('audiostream', 'platform', 'ios_ext.m')]))
 
 elif platform == "darwin":
-    include_dirs.append('/usr/local/include/SDL2')
+    include_dirs.append('/usr/local/include/SDL')
     extensions.append(makeExtension('audiostream.platform.plat_mac',
         [join('audiostream', 'platform', 'mac_ext.m')]))
 

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,8 @@ extensions = []
 if not have_cython:
     libraries = ['SDL2', 'SDL2_mixer'] if use_sdl2 else ['sdl', 'sdl_mixer']
 else:
-    include_dirs.insert(0, '.')
+    include_dirs.append('.')
+    include_dirs.append('/usr/include/SDL')
 
 # generate an Extension object from its dotted name
 def makeExtension(extName, files=None):

--- a/setup.py
+++ b/setup.py
@@ -30,19 +30,19 @@ else:
         raise
 
 # configure the env
-libraries = ['SDL', 'SDL_mixer']
+libraries = ['SDL2', 'SDL2_mixer']
 library_dirs = []
-include_dirs = ['/usr/include/SDL']
+include_dirs = ['/usr/include/SDL2', '/home/kivy/.buildozer/android/platform/android-ndk-r9c/sources/android/support/include']
 extra_objects = []
 extra_compile_args =['-ggdb', '-O2']
 extra_link_args = []
 extensions = []
 
 if not have_cython:
-    libraries = ['sdl', 'sdl_mixer']
+    libraries = ['SDL2', 'SDL2_mixer']
 else:
     include_dirs.append('.')
-    include_dirs.append('/usr/include/SDL')
+    include_dirs.append('/usr/include/SDL2')
 
 # generate an Extension object from its dotted name
 def makeExtension(extName, files=None):
@@ -67,7 +67,7 @@ if platform == 'android':
 elif platform == 'ios':
     include_dirs = [
             join(kivy_ios_root, 'build', 'include'),
-            join(kivy_ios_root, 'build', 'include', 'SDL')]
+            join(kivy_ios_root, 'build', 'include', 'SDL2')]
     extra_link_args = [
         '-L', join(kivy_ios_root, 'build', 'lib'),
         '-undefined', 'dynamic_lookup']
@@ -75,7 +75,7 @@ elif platform == 'ios':
         [join('audiostream', 'platform', 'ios_ext.m')]))
 
 elif platform == "darwin":
-    include_dirs.append('/usr/local/include/SDL')
+    include_dirs.append('/usr/local/include/SDL2')
     extensions.append(makeExtension('audiostream.platform.plat_mac',
         [join('audiostream', 'platform', 'mac_ext.m')]))
 

--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,17 @@ else:
         raise
 
 # configure the env
-use_sdl2 = os.environ.get('USE_SDL2')
-libraries = ['SDL2', 'SDL2_mixer'] if use_sdl2 else ['SDL', 'SDL_mixer']
+use_sdl2 = environ.get('USE_SDL2')
+if use_sdl2:
+    include_dirs = ['/usr/include/SDL2']
+    sdl_include_dir = environ.get('SDL2_INCLUDE_DIR')
+    if sdl_include_dir:
+        include_dirs.append(sdl_include_dir)
+    libraries = ['SDL2', 'SDL2_mixer']
+else 
+    libraries = ['SDL', 'SDL_mixer']
+    include_dirs = ['/usr/include/SDL']
 library_dirs = []
-include_dirs = ['/usr/include/SDL2', '/home/kivy/.buildozer/android/platform/android-ndk-r9c/sources/android/support/include'] if use_sdl2 else ['/usr/include/SDL2']
 extra_objects = []
 extra_compile_args =['-ggdb', '-O2']
 extra_link_args = []

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,9 @@ else:
 use_sdl2 = environ.get('USE_SDL2')
 if use_sdl2:
     include_dirs = ['/usr/include/SDL2']
+    sdl_include_dir = environ.get('SDL2_INCLUDE_DIR')
+    if sdl_include_dir:
+        include_dirs.append(sdl_include_dir)
     libraries = ['SDL2', 'SDL2_mixer']
 else 
     libraries = ['SDL', 'SDL_mixer']


### PR DESCRIPTION
I managed to get audiostream compiled and working using sdl2 on android.
Mostly just changed instances of 'SDL' into 'SDL2' and added an include.
To be viable tho, this needs three things:
1. able to use sdl or sdl2 - I do not know how to detect which is being used to add if/else clauses
2. make the include system-independent - I'm not sure how to refer to that directory from environmental variables, I'm not sure how to get the ndk path.
3. the python-for-android init file needs to be edited as well, as in: https://github.com/kivy/python-for-android/pull/1178