### PR TITLE
Allow multiple SDL2 include dirs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ if use_sdl2:
     include_dirs = []
     sdl_include_dir = environ.get('SDL2_INCLUDE_DIR')
     if sdl_include_dir:
-        include_dirs.append(sdl_include_dir)
+        include_dirs.extend(sdl_include_dir.split(':'))
     include_dirs.append('/usr/include/SDL2')
     libraries = ['SDL2', 'SDL2_mixer']
 else:


### PR DESCRIPTION
For example using SDL2/SDL2-mixer from homebrew on macOS requires the following CLI:

```
env USE_SDL2=1 SDL2_INCLUDE_DIR="/usr/local/Cellar/sdl2/2.0.12_1/include/SDL2/:/usr/local/Cellar/sdl2_mixer/2.0.4/include/SDL2/" pip install git+https://github.com/kivy/audiostream
```