### PR TITLE
Fix for one of the parts of #25: Missing symbol on android

### DIFF
--- a/audiostream/platform/android_ext.h
+++ b/audiostream/platform/android_ext.h
@@ -6,7 +6,12 @@
 #include <android/log.h>
 #include <string.h>
 
-extern JNIEnv *SDL_ANDROID_GetJNIEnv();
+#if SDL_VERSION_ATLEAST(2,0,0)
+    #define SDL_ANDROID_GetJNIEnv SDL_AndroidGetJNIEnv
+#else
+    extern JNIEnv *SDL_ANDROID_GetJNIEnv();
+#endif
+
 
 typedef void (*audio_callback_t)(char *buffer, int bufsize);
 static audio_callback_t audio_callback = NULL;


### PR DESCRIPTION
Looks like this change wasn't made when the SDL2 upgrade was implemented.

Other bugs on this platform are still extant, but this fix looks important.  #25 .  EDIT: force-pushed with clearer commit message